### PR TITLE
Fix SearchFilter to use comma-chaining

### DIFF
--- a/src/xivapi.service.ts
+++ b/src/xivapi.service.ts
@@ -55,7 +55,7 @@ export class XivapiService {
         let queryParams: HttpParams = this.prepareQueryString(options);
         if (options.filters) {
             const filterChain: string = options.filters.reduce((chain, filter) => {
-                return `${chain}${filter.column}${filter.operator}${filter.value}&`;
+                return `${chain}${filter.column}${filter.operator}${filter.value},`;
             }, '').slice(0, -1);
             queryParams = queryParams.set('filters', filterChain);
         }


### PR DESCRIPTION
Filters are comma-separated, parameters still use normal query params. This PR fixes the chain delimiter to use commas.