### PR TITLE
Fix missing search options

### DIFF
--- a/src/model/xivapi-options.ts
+++ b/src/model/xivapi-options.ts
@@ -8,4 +8,32 @@ export interface XivapiOptions {
      * for example: language=fr&string=LeAwsome will search for LeAwesome on the field Name_fr.
      */
     language?: string;
+
+     /**
+     * Pull specific columns from the data. By default the result provides every column.
+     * You can request specific pieces of information from a result by plugging in the column names.
+     * For extended content you use dot notation to access it, for example:
+     *
+     * To access the data in a search on the Items index, these you could request the columns:
+     *
+     * columns=Items.0.Name,Items.1.Name
+     * If you imagine an array having 50 items, this could be tedious and will eat into your maximum column count.
+     * You can therefore use a count format, eg:
+     *
+     * columns=Items.*50.Name
+     * This will return 50 rows from the column Items using the index Name
+     *
+     * There are restrictions on the number of columns you can query, the column character length and the maximum items.
+     * By default these are pretty strict so it is recommended to create a Developer App to be provided a key to increase your limits.
+     */
+    columns?: string[];
+
+    /**
+    * You can add tracking counters to your app for whatever purpose using "tags". Tags will appear in your dashboard with a counter
+    * next to them. You can have as many tags you would like and counts will store for a period of 30 days before taping off
+    * and being removed if they become inactive.
+    *
+    * A tag must be alpha numeric and allows dashes and underscores.
+    */
+    tags?: string[];
 }

--- a/src/model/xivapi-options.ts
+++ b/src/model/xivapi-options.ts
@@ -10,11 +10,11 @@ export interface XivapiOptions {
     language?: string;
 
      /**
-     * Pull specific columns from the data. By default the result provides every column.
-     * You can request specific pieces of information from a result by plugging in the column names.
+     * Pull specific columns from the data. By default the list just provides the ID, and result provides every column.
+     * You can request specific pieces of information from a list or result by plugging in the column names.
      * For extended content you use dot notation to access it, for example:
      *
-     * To access the data in a search on the Items index, these you could request the columns:
+     * To access the data in Items or a search on the Items index, you could request with these columns:
      *
      * columns=Items.0.Name,Items.1.Name
      * If you imagine an array having 50 items, this could be tedious and will eat into your maximum column count.
@@ -33,7 +33,8 @@ export interface XivapiOptions {
     * next to them. You can have as many tags you would like and counts will store for a period of 30 days before taping off
     * and being removed if they become inactive.
     *
-    * A tag must be alpha numeric and allows dashes and underscores.
+    * A tag must be alpha numeric and allows dashes and underscores, however this is not checked or validated until it hits XivAPI.
+    * A GitHub issue to add support for this to TypeScript can be found at https://github.com/Microsoft/TypeScript/issues/6579
     */
     tags?: string[];
 }

--- a/src/model/xivapi-request-options.ts
+++ b/src/model/xivapi-request-options.ts
@@ -28,25 +28,6 @@ export interface XivapiRequestOptions extends XivapiOptions {
     ids?: number[];
 
     /**
-     * Pull specific columns from the data. By default the list just provides the ID.
-     * You can request specific pieces of information from a list by plugging in the column names.
-     * For extended content you use dot notation to access it, for example:
-     *
-     * To access the data in Items these you would request the columns:
-     *
-     * columns=Items.0.Name,Items.1.Name
-     * If you imagine an array having 50 items, this could be tedious and will eat into your maximum column count.
-     * You can therefore use a count format, eg:
-     *
-     * columns=Items.*50.Name
-     * This will return 50 rows from the column Items using the index Name
-     *
-     * There are restrictions on the number of columns you can query, the column character length and the maximum items.
-     * By default these are pretty strict so it is recommended to create a Developer App to be provided a key to increase your limits.
-     */
-    columns?: string[];
-
-    /**
      * View the current column and schema information of the content. This will provide 2 objects: columns and schema.
      *
      * columns - This is list of all columns in dot notation. For example an achievement would have: AchievementCategory.AchievementKind.ID


### PR DESCRIPTION
Move column to be global, and add tags. Tags doesn't validate the string format, but the documentation includes a link to the GH issue tracking string validation in TypeScript.